### PR TITLE
Fix edge case where setting an LED to an RGB value with G as zero fails

### DIFF
--- a/js/Launchpad.js
+++ b/js/Launchpad.js
@@ -84,7 +84,7 @@ class Launchpad extends EventEmitter {
 
   LedOn(led, color, g, b) {
     this.leds.push(led);
-    if (g) {
+    if (g !== undefined) {
       if (!this.sysex) {
         throw new Error(`Sysex is Not Enabled. Cannot use RGB values!`);
       }


### PR DESCRIPTION
If the g value when setting an RGB color is 0 (eg. 255, 0, 255 for pink), the check fails as specifically 0 returns false.

Any non-zero number as the g parameter, like (255, 1, 255) will successfully set the color to the expected pink.